### PR TITLE
release: publish resources for 24.0.1-IF007.tar

### DIFF
--- a/24.0.1-IF007.tar
+++ b/24.0.1-IF007.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:396b27169ab6c497897b40b645275948bb12c883d8020220c89aeab3dc21a47b
+size 106905600


### PR DESCRIPTION
Release of BAW on Containers for version 24.0.1-IF007