### PR TITLE
release: publish resources for 24.0.0-IF009.tar

### DIFF
--- a/24.0.0-IF009.tar
+++ b/24.0.0-IF009.tar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89cb1f193bc2f5710fb409e7a2d321d333e2900fce5fca857ae82b0aa495f186
+oid sha256:bdd73431d8aeb3d3604802fad60fa3b4c5f1274fbf9d5e735ca32c15bf42aedc
 size 106813440

--- a/24.0.0-IF009.tar
+++ b/24.0.0-IF009.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89cb1f193bc2f5710fb409e7a2d321d333e2900fce5fca857ae82b0aa495f186
+size 106813440

--- a/24.0.0-IF009.tar
+++ b/24.0.0-IF009.tar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bdd73431d8aeb3d3604802fad60fa3b4c5f1274fbf9d5e735ca32c15bf42aedc
+oid sha256:995730bef3505ed23db411579570e965043e46e4cca862044101179959ef87dc
 size 106813440


### PR DESCRIPTION
Release of BAW on Containers for version 24.0.0-IF009